### PR TITLE
Mention dyn-clonable in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,10 @@ struct Container {
 }
 ```
 
-<!-- (TODO: uncomment after objekt-clonable updates to dyn-clone 1.0)
-
-Check out the [objekt-clonable] crate which provides the same Clone impl for
+Check out the [dyn-clonable] crate which provides the same Clone impl for
 `Box<dyn MyTrait>` in a more concise attribute form.
 
-[objekt-clonable]: https://github.com/kardeiz/objekt-clonable
--->
+[dyn-clonable]: https://github.com/kardeiz/objekt-clonable
 
 <br>
 


### PR DESCRIPTION
It seems that dyn-clonable has now upgraded to 1.0: https://github.com/kardeiz/objekt-clonable/blob/fd987e0accfc033fba239f501e5b1b030aa0d01d/dyn-clonable/Cargo.toml#L12; hopefully I didn't miss anything.