### PR TITLE
use core and alloc instead of std

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -86,7 +86,7 @@ macro_rules! __internal_clone_trait_object {
 
     // The impl.
     (impl ($($generics:tt)*) ($($path:tt)*) ($($bound:tt)*)) => {
-        impl<'clone, $($generics)*> $crate::private::clone::Clone for $crate::private::boxed::Box<dyn $($path)* + 'clone> where $($bound)* {
+        impl<'clone, $($generics)*> $crate::private_core::clone::Clone for $crate::private_alloc::boxed::Box<dyn $($path)* + 'clone> where $($bound)* {
             fn clone(&self) -> Self {
                 $crate::clone_box(&**self)
             }
@@ -99,6 +99,7 @@ macro_rules! __internal_clone_trait_object {
 #[cfg(test)]
 mod tests {
     use crate::DynClone;
+    use alloc::boxed::Box;
 
     fn assert_clone<T: Clone>() {}
 


### PR DESCRIPTION
this crate doesn't require more than core and alloc thus I converted to no_std.

test has been changed but it should be straightforward.

alloc crate is stable since version 1.36.0 (2019-07-04) (this is why CI fails), do you want to support <1.36 ? (if so I can manage some support for core/alloc until 1.36 only, behind some feature or something)