### PR TITLE
Add impls for str and [T]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,8 @@ pub mod private {
 mod sealed {
     pub trait Sealed {}
     impl<T: Clone> Sealed for T {}
+    impl Sealed for str {}
+    impl<T: Clone> Sealed for [T] {}
     pub struct Private;
 }
 
@@ -127,6 +129,21 @@ where
     T: Clone,
 {
     fn __clone_box(&self, _: Private) -> *mut () {
-        Box::into_raw(Box::new(self.clone())) as *mut ()
+        Box::<T>::into_raw(Box::new(self.clone())) as *mut ()
+    }
+}
+
+impl DynClone for str {
+    fn __clone_box(&self, _: Private) -> *mut () {
+        Box::<str>::into_raw(Box::from(self)) as *mut ()
+    }
+}
+
+impl<T> DynClone for [T]
+where
+    T: Clone,
+{
+    fn __clone_box(&self, _: Private) -> *mut () {
+        Box::<[T]>::into_raw(self.iter().cloned().collect()) as *mut ()
     }
 }

--- a/tests/ui/missing-supertrait.stderr
+++ b/tests/ui/missing-supertrait.stderr
@@ -4,6 +4,9 @@ error[E0277]: the trait bound `dyn MyTrait: Clone` is not satisfied
 3   | dyn_clone::clone_trait_object!(MyTrait);
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `dyn MyTrait`
     |
+    = help: the following other types implement trait `DynClone`:
+              [T]
+              str
     = note: required because of the requirements on the impl of `DynClone` for `dyn MyTrait`
 note: required by a bound in `clone_box`
    --> src/lib.rs
@@ -18,6 +21,9 @@ error[E0277]: the trait bound `dyn MyTrait + Send: Clone` is not satisfied
 3   | dyn_clone::clone_trait_object!(MyTrait);
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `dyn MyTrait + Send`
     |
+    = help: the following other types implement trait `DynClone`:
+              [T]
+              str
     = note: required because of the requirements on the impl of `DynClone` for `dyn MyTrait + Send`
 note: required by a bound in `clone_box`
    --> src/lib.rs
@@ -32,6 +38,9 @@ error[E0277]: the trait bound `dyn MyTrait + Sync: Clone` is not satisfied
 3   | dyn_clone::clone_trait_object!(MyTrait);
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `dyn MyTrait + Sync`
     |
+    = help: the following other types implement trait `DynClone`:
+              [T]
+              str
     = note: required because of the requirements on the impl of `DynClone` for `dyn MyTrait + Sync`
 note: required by a bound in `clone_box`
    --> src/lib.rs
@@ -46,6 +55,9 @@ error[E0277]: the trait bound `dyn MyTrait + Send + Sync: Clone` is not satisfie
 3   | dyn_clone::clone_trait_object!(MyTrait);
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `dyn MyTrait + Send + Sync`
     |
+    = help: the following other types implement trait `DynClone`:
+              [T]
+              str
     = note: required because of the requirements on the impl of `DynClone` for `dyn MyTrait + Send + Sync`
 note: required by a bound in `clone_box`
    --> src/lib.rs


### PR DESCRIPTION
This makes it so that if you have a trait with DynClone supertrait:

```rust
trait MyTrait: DynClone {
    …
}
```

then you are able to have impls that apply to `str` and `[T]`, unlike previously.

```rust
// now supported
impl MyTrait for str {…}

impl MyTrait for [Thing] {…}
```