### PR TITLE
add portable-atomic-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,15 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/dyn-clone"
 rust-version = "1.45"
 
+[dependencies]
+portable-atomic-util = { version = "0.2.4", optional = true, default-features = false, features = ["alloc"] }
+
 [dev-dependencies]
 rustversion = "1.0"
 trybuild = { version = "1.0.66", features = ["diff"] }
+
+[features]
+portable_atomic = ["portable-atomic-util"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,11 @@ mod sealed {
 use crate::sealed::{Private, Sealed};
 use alloc::boxed::Box;
 use alloc::rc::Rc;
+
+#[cfg(not(feature = "portable_atomic"))]
 use alloc::sync::Arc;
+#[cfg(feature = "portable_atomic")]
+use portable_atomic_util::Arc;
 
 /// This trait is implemented by any type that implements [`std::clone::Clone`].
 pub trait DynClone: Sealed {


### PR DESCRIPTION
This is for using portable-atomic-util for target that uses portable-atomic, especially if they don't have sync